### PR TITLE
Add command for service check

### DIFF
--- a/main.go
+++ b/main.go
@@ -562,7 +562,7 @@ func main() {
 
 	commandCommand := cli.Command{
 		Name:  "command",
-		Usage: "Execute ambari commands on Ambari server (START/STOP/RESTART)",
+		Usage: "Execute ambari commands on Ambari server (START/STOP/RESTART/SERVICE_CHECK)",
 		Action: func(c *cli.Context) error {
 			ambariServer := ambari.GetActiveAmbari()
 			validateActiveAmbari(ambariServer)
@@ -573,6 +573,10 @@ func main() {
 			}
 			if len(c.String("services")) == 0 && len(c.String("components")) == 0 {
 				fmt.Println("It is required to provide --components (-c) or --services (-s) flag")
+				os.Exit(1)
+			}
+			if command == "SERVICE_CHECK" && len(c.String("services")) == 0 {
+				fmt.Println("Service check can be performed only on services, not components")
 				os.Exit(1)
 			}
 			filter := ambari.CreateFilter(strings.ToUpper(c.String("services")),


### PR DESCRIPTION
```
$ ambarictl command -s KAFKA,ZOOKEEPER SERVICE_CHECK
Command SERVICE_CHECK has been sent to KAFKA,ZOOKEEPER (services)
```

```
2018-12-01T23:22:08.768Z, User(admin), RemoteIp(192.168.16.1), Operation(Request from server), RequestType(POST), url(http://u1601.ambari.apache.org:8080/api/v1/clusters/TEST/requests), ResultStatus(202 Accepted), Command(KAFKA_SERVICE_CHECK), Cluster name(TEST)
2018-12-01T23:22:08.769Z, User(admin), Operation(SERVICE_CHECK KAFKA_SERVICE_CHECK), Details(SERVICE_CHECK KAFKA), Status(QUEUED), RequestId(16), TaskId(11), Hostname(u1601.ambari.apache.org)
2018-12-01T23:22:08.802Z, User(admin), RemoteIp(192.168.16.1), Operation(Request from server), RequestType(POST), url(http://u1601.ambari.apache.org:8080/api/v1/clusters/TEST/requests), ResultStatus(202 Accepted), Command(ZOOKEEPER_QUORUM_SERVICE_CHECK), Cluster name(TEST)
2018-12-01T23:22:12.416Z, User(admin), Operation(Check service (KAFKA) by ambarictl), Status(COMPLETED), RequestId(16)
2018-12-01T23:22:12.416Z, User(admin), Operation(SERVICE_CHECK KAFKA_SERVICE_CHECK), Details(SERVICE_CHECK KAFKA), Status(COMPLETED), RequestId(16), TaskId(11), Hostname(u1601.ambari.apache.org)
2018-12-01T23:22:12.851Z, User(admin), Operation(Check service (ZOOKEEPER) by ambarictl), Status(IN_PROGRESS), RequestId(17)
2018-12-01T23:22:12.852Z, User(admin), Operation(SERVICE_CHECK ZOOKEEPER_QUORUM_SERVICE_CHECK), Details(SERVICE_CHECK ZOOKEEPER), Status(QUEUED), RequestId(17), TaskId(12), Hostname(u1601.ambari.apache.org)
2018-12-01T23:22:17.170Z, User(admin), Operation(Check service (ZOOKEEPER) by ambarictl), Status(COMPLETED), RequestId(17)
2018-12-01T23:22:17.170Z, User(admin), Operation(SERVICE_CHECK ZOOKEEPER_QUORUM_SERVICE_CHECK), Details(SERVICE_CHECK ZOOKEEPER), Status(COMPLETED), RequestId(17), TaskId(12), Hostname(u1601.ambari.apache.org)
```