### PR TITLE
Cannot restart or stop services

### DIFF
--- a/ambari/actions.go
+++ b/ambari/actions.go
@@ -215,8 +215,8 @@ func (a AmbariRegistry) restartAmbariServiceOrComponent(useComponentFilter bool,
 			a.RestartComponent(component)
 		}
 	} else if useServiceFilter {
-		for _, component := range filter.Components {
-			a.RestartService(component)
+		for _, service := range filter.Services {
+			a.RestartService(service)
 		}
 	}
 }
@@ -227,8 +227,8 @@ func (a AmbariRegistry) stopAmbariServiceOrComponent(useComponentFilter bool, fi
 			a.StopComponent(component)
 		}
 	} else if useServiceFilter {
-		for _, component := range filter.Services {
-			a.StartService(component)
+		for _, service := range filter.Services {
+			a.StopService(service)
 		}
 	}
 }
@@ -239,8 +239,8 @@ func (a AmbariRegistry) startAmbariServiceOrComponent(useComponentFilter bool, f
 			a.StartComponent(component)
 		}
 	} else if useServiceFilter {
-		for _, component := range filter.Services {
-			a.StartService(component)
+		for _, service := range filter.Services {
+			a.StartService(service)
 		}
 	}
 }


### PR DESCRIPTION
```
$ ambarictl command -s KAFKA STOP
Command STOP has been sent to KAFKA (services)
```

```
2018-12-01T23:44:01.021Z, User(admin), Operation(Stop service (KAFKA) by ambarictl), Status(IN_PROGRESS), RequestId(23)
2018-12-01T23:44:01.021Z, User(admin), Operation(STOP KAFKA_BROKER), Status(QUEUED), RequestId(23), TaskId(16), Hostname(u1601.ambari.apache.org)
2018-12-01T23:44:05.598Z, User(admin), Operation(Stop service (KAFKA) by ambarictl), Status(COMPLETED), RequestId(23)
2018-12-01T23:44:05.598Z, User(admin), Operation(STOP KAFKA_BROKER), Status(COMPLETED), RequestId(23), TaskId(16), Hostname(u1601.ambari.apache.org)
```

Restart also works, but it's a bit flaky (since it issues separate stop and start commands, and doesn't wait for stop to complete.)

fixes #3